### PR TITLE
Add Pages deploy workflow; normalize and validate PAGES_URL, remove DIGEST_REPO env from scheduled jobs

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -40,7 +40,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.ANTHROPIC_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || secrets.ANTHROPIC_MODEL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
-          DIGEST_REPO: ${{ github.repository }}
         run: pnpm start
 
       - name: Commit digest files
@@ -59,7 +58,6 @@ jobs:
 
       - name: Update web manifest
         env:
-          DIGEST_REPO: ${{ github.repository }}
           PAGES_URL: ${{ vars.PAGES_URL || secrets.PAGES_URL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
         run: pnpm manifest
@@ -77,7 +75,6 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          DIGEST_REPO: ${{ github.repository }}
           PAGES_URL: ${{ vars.PAGES_URL || secrets.PAGES_URL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
         run: pnpm notify

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,55 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'index.html'
+      - 'manifest.json'
+      - 'feed.xml'
+      - 'report-registry.json'
+      - 'tracks.runtime.json'
+      - 'digests/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build static artifact
+        run: |
+          mkdir -p _site
+          cp index.html _site/
+          cp manifest.json _site/
+          cp feed.xml _site/
+          cp report-registry.json _site/
+          cp tracks.runtime.json _site/
+          cp -R digests _site/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/monthly-digest.yml
+++ b/.github/workflows/monthly-digest.yml
@@ -38,7 +38,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.ANTHROPIC_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || secrets.ANTHROPIC_MODEL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
-          DIGEST_REPO: ${{ github.repository }}
         run: pnpm monthly
 
       - name: Commit monthly report
@@ -57,7 +56,6 @@ jobs:
 
       - name: Update web manifest
         env:
-          DIGEST_REPO: ${{ github.repository }}
           PAGES_URL: ${{ vars.PAGES_URL || secrets.PAGES_URL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
         run: pnpm manifest
@@ -75,7 +73,6 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          DIGEST_REPO: ${{ github.repository }}
           PAGES_URL: ${{ vars.PAGES_URL || secrets.PAGES_URL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
         run: pnpm notify

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -38,7 +38,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.ANTHROPIC_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || secrets.ANTHROPIC_MODEL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
-          DIGEST_REPO: ${{ github.repository }}
         run: pnpm weekly
 
       - name: Commit weekly report
@@ -57,7 +56,6 @@ jobs:
 
       - name: Update web manifest
         env:
-          DIGEST_REPO: ${{ github.repository }}
           PAGES_URL: ${{ vars.PAGES_URL || secrets.PAGES_URL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
         run: pnpm manifest
@@ -75,7 +73,6 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          DIGEST_REPO: ${{ github.repository }}
           PAGES_URL: ${{ vars.PAGES_URL || secrets.PAGES_URL }}
           REPORT_LANGS: ${{ vars.REPORT_LANGS || secrets.REPORT_LANGS }}
         run: pnpm notify

--- a/src/generate-manifest.ts
+++ b/src/generate-manifest.ts
@@ -33,9 +33,26 @@ const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "
 
 function resolveSiteUrl(): string {
   const explicit = process.env["PAGES_URL"] ?? process.env["SITE_URL"];
-  if (explicit) return explicit.replace(/\/$/, "");
-
   const repo = process.env["DIGEST_REPO"] ?? process.env["GITHUB_REPOSITORY"];
+
+  if (explicit) {
+    const normalizedExplicit = explicit.replace(/\/$/, "");
+    if (repo) {
+      const [owner, name] = repo.split("/");
+      if (owner && name) {
+        const defaultUrl = `https://${owner}.github.io/${name}`;
+        const explicitGithubPages = /^https:\/\/[^/]+\.github\.io\/.+/.test(normalizedExplicit);
+        if (explicitGithubPages && normalizedExplicit !== defaultUrl) {
+          console.warn(
+            `[manifest] PAGES_URL (${normalizedExplicit}) does not match DIGEST_REPO (${repo}). ` +
+              `This can produce dead links in feed/notifications. Expected: ${defaultUrl}`,
+          );
+        }
+      }
+    }
+    return normalizedExplicit;
+  }
+
   if (repo) {
     const [owner, name] = repo.split("/");
     if (owner && name) return `https://${owner}.github.io/${name}`;

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -24,9 +24,26 @@ interface ReportRegistryEntry {
 
 function resolvePagesUrl(): string {
   const explicit = process.env["PAGES_URL"] ?? process.env["SITE_URL"];
-  if (explicit) return explicit.replace(/\/$/, "");
-
   const repo = process.env["DIGEST_REPO"] ?? process.env["GITHUB_REPOSITORY"];
+
+  if (explicit) {
+    const normalizedExplicit = explicit.replace(/\/$/, "");
+    if (repo) {
+      const [owner, name] = repo.split("/");
+      if (owner && name) {
+        const defaultUrl = `https://${owner}.github.io/${name}`;
+        const explicitGithubPages = /^https:\/\/[^/]+\.github\.io\/.+/.test(normalizedExplicit);
+        if (explicitGithubPages && normalizedExplicit !== defaultUrl) {
+          console.warn(
+            `[notify] PAGES_URL (${normalizedExplicit}) does not match DIGEST_REPO (${repo}). ` +
+              `Telegram message links may be invalid. Expected: ${defaultUrl}`,
+          );
+        }
+      }
+    }
+    return normalizedExplicit;
+  }
+
   if (repo) {
     const [owner, name] = repo.split("/");
     if (owner && name) return `https://${owner}.github.io/${name}`;


### PR DESCRIPTION
### Motivation

- Ensure the site base URL is normalized and consistent so generated feed and notification links are valid.  
- Avoid relying on `DIGEST_REPO` being injected into scheduled workflow steps and reduce redundant env propagation.  
- Add a dedicated GitHub Pages deployment workflow so generated artifacts in the repository are published automatically.

### Description

- Add `.github/workflows/deploy-pages.yml` to build a static `_site` artifact and deploy it with `actions/deploy-pages@v4`.  
- Remove `DIGEST_REPO: ${{ github.repository }}` environment propagation from the daily, weekly, and monthly workflow steps.  
- Update `resolveSiteUrl` in `src/generate-manifest.ts` and `resolvePagesUrl` in `src/notify.ts` to normalize trailing slashes, warn when an explicit `PAGES_URL` appears to be a GitHub Pages URL that does not match the derived `DIGEST_REPO` default, and keep the same repo-derived fallback behavior.  

### Testing

- Ran TypeScript build/typecheck via `pnpm build` to validate the updated files and the changes compiled successfully.  
- No unit tests were modified or added as part of this change.  
- Workflow YAML files were added/updated and are intended to be exercised by GitHub Actions on merge; no further CI failures were observed locally during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f72be7969c8329bbeef9f0008a1b14)