### PR TITLE
style: fix CI formatting failures by running Prettier

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -335,7 +335,9 @@ function toContentSource(source: RawContentSource): ContentSource | undefined {
         discovery: {
           kind: "sitemap",
           url,
-          ...(toStringArray(source.discovery.prefixes) ? { prefixes: toStringArray(source.discovery.prefixes) } : {}),
+          ...(toStringArray(source.discovery.prefixes)
+            ? { prefixes: toStringArray(source.discovery.prefixes) }
+            : {}),
         },
         extract: { mode },
       };
@@ -349,8 +351,12 @@ function toContentSource(source: RawContentSource): ContentSource | undefined {
         discovery: {
           kind: "sitemap-index",
           url,
-          ...(toStringArray(source.discovery.includes) ? { includes: toStringArray(source.discovery.includes) } : {}),
-          ...(toStringArray(source.discovery.excludes) ? { excludes: toStringArray(source.discovery.excludes) } : {}),
+          ...(toStringArray(source.discovery.includes)
+            ? { includes: toStringArray(source.discovery.includes) }
+            : {}),
+          ...(toStringArray(source.discovery.excludes)
+            ? { excludes: toStringArray(source.discovery.excludes) }
+            : {}),
         },
         extract: { mode },
       };
@@ -410,14 +416,19 @@ function parseTracks(rawTracks: RawTrack[] | undefined): RadarTrack[] {
         kind: "content_group",
         name: track.name?.trim() || track.id,
         analysisProfile: track.analysis_profile?.trim(),
-        sources: Array.isArray(track.sources) ? track.sources.map(toContentSource).filter((source): source is ContentSource => Boolean(source)) : [],
+        sources: Array.isArray(track.sources)
+          ? track.sources.map(toContentSource).filter((source): source is ContentSource => Boolean(source))
+          : [],
         ...(toTrackReport(track.report) ? { report: toTrackReport(track.report) } : {}),
       },
     ];
   });
 }
 
-function findGithubTrack(tracks: RadarTrack[], predicate: (track: GitHubGroupTrack) => boolean): GitHubGroupTrack | undefined {
+function findGithubTrack(
+  tracks: RadarTrack[],
+  predicate: (track: GitHubGroupTrack) => boolean,
+): GitHubGroupTrack | undefined {
   return tracks.find((track): track is GitHubGroupTrack => track.kind === "github_group" && predicate(track));
 }
 
@@ -426,13 +437,18 @@ function deriveSkillsRepos(track: GitHubGroupTrack | undefined): RepoConfig[] {
   return track.members;
 }
 
-function deriveOpenclawConfig(track: GitHubGroupTrack | undefined): { openclaw: RepoConfig; openclawPeers: RepoConfig[] } {
+function deriveOpenclawConfig(track: GitHubGroupTrack | undefined): {
+  openclaw: RepoConfig;
+  openclawPeers: RepoConfig[];
+} {
   if (!track || track.members.length === 0) {
     return { openclaw: DEFAULT_OPENCLAW, openclawPeers: DEFAULT_OPENCLAW_PEERS };
   }
 
   const primary =
-    (track.primaryMemberId ? track.members.find((member) => member.id === track.primaryMemberId) : undefined) ??
+    (track.primaryMemberId
+      ? track.members.find((member) => member.id === track.primaryMemberId)
+      : undefined) ??
     track.members.find((member) => member.id === "openclaw") ??
     track.members[0];
 
@@ -481,7 +497,15 @@ function buildLegacyConfig(raw: RawConfig): RadarConfig {
     return track;
   });
 
-  return { cliRepos, skillsRepo, skillsRepos, openclaw, openclawPeers, contentTracks: deriveContentTracks(tracks), tracks };
+  return {
+    cliRepos,
+    skillsRepo,
+    skillsRepos,
+    openclaw,
+    openclawPeers,
+    contentTracks: deriveContentTracks(tracks),
+    tracks,
+  };
 }
 
 function buildTracksConfig(raw: RawConfig, tracks: RadarTrack[]): RadarConfig {

--- a/src/hn.ts
+++ b/src/hn.ts
@@ -88,7 +88,9 @@ async function fetchWithRetry(url: string, init: RetryRequestInit = {}): Promise
 
       if (attempt < FETCH_MAX_RETRIES && isRetryableStatus(response.status)) {
         const waitMs = getRetryDelayMs(attempt, response.headers.get("retry-after"));
-        console.warn(`  [hn] ${response.status} for ${url} — retry ${attempt + 1}/${FETCH_MAX_RETRIES} in ${waitMs}ms`);
+        console.warn(
+          `  [hn] ${response.status} for ${url} — retry ${attempt + 1}/${FETCH_MAX_RETRIES} in ${waitMs}ms`,
+        );
         await sleep(waitMs);
         continue;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,9 @@ const {
   contentTracks: CONTENT_TRACKS,
 } = loadedConfig;
 
-const CONTENT_SOURCE_ID_COUNTS = CONTENT_TRACKS.flatMap((track) => track.sources.map((source) => source.id)).reduce(
-  (map, id) => map.set(id, (map.get(id) ?? 0) + 1),
-  new Map<string, number>(),
-);
+const CONTENT_SOURCE_ID_COUNTS = CONTENT_TRACKS.flatMap((track) =>
+  track.sources.map((source) => source.id),
+).reduce((map, id) => map.set(id, (map.get(id) ?? 0) + 1), new Map<string, number>());
 
 function getContentSourceRuntimeId(trackId: string, sourceId: string): string {
   return (CONTENT_SOURCE_ID_COUNTS.get(sourceId) ?? 0) > 1 ? `${trackId}:${sourceId}` : sourceId;
@@ -168,7 +167,13 @@ async function fetchAllData(
         if (errors.length > 0) {
           console.error(`  [${cfg.id}] fetch failed partially: ${errors.join(" | ")}`);
         }
-        return { cfg, issues, prs, releases, ...(errors.length > 0 ? { fetchError: errors.join(" | ") } : {}) };
+        return {
+          cfg,
+          issues,
+          prs,
+          releases,
+          ...(errors.length > 0 ? { fetchError: errors.join(" | ") } : {}),
+        };
       }),
     ),
     Promise.all(
@@ -179,7 +184,12 @@ async function fetchAllData(
             if (data.fetchError) {
               console.error(`  [skills/${cfg.id}] fetch failed partially: ${data.fetchError}`);
             }
-            return { cfg, prs: data.prs, issues: data.issues, ...(data.fetchError ? { fetchError: data.fetchError } : {}) };
+            return {
+              cfg,
+              prs: data.prs,
+              issues: data.issues,
+              ...(data.fetchError ? { fetchError: data.fetchError } : {}),
+            };
           })
           .catch((err): SkillsRepoFetch => {
             const fetchError = formatError(err);
@@ -190,12 +200,15 @@ async function fetchAllData(
     ),
     CONTENT_TRACKS.length > 0
       ? Promise.all(
-          CONTENT_TRACKS.map(async (track): Promise<ContentTrackFetch> => ({
-            track,
-            results: await Promise.all(
-              track.sources.map((source) =>
-                fetchSiteContent({ ...source, id: getContentSourceRuntimeId(track.id, source.id) }, webState).catch(
-                  (err: unknown): WebFetchResult => {
+          CONTENT_TRACKS.map(
+            async (track): Promise<ContentTrackFetch> => ({
+              track,
+              results: await Promise.all(
+                track.sources.map((source) =>
+                  fetchSiteContent(
+                    { ...source, id: getContentSourceRuntimeId(track.id, source.id) },
+                    webState,
+                  ).catch((err: unknown): WebFetchResult => {
                     console.error(`  [content/${track.id}/${source.id}] fetch failed: ${err}`);
                     return {
                       sourceId: source.id,
@@ -204,11 +217,11 @@ async function fetchAllData(
                       newItems: [],
                       totalDiscovered: 0,
                     };
-                  },
+                  }),
                 ),
               ),
-            ),
-          })),
+            }),
+          ),
         )
       : Promise.resolve([]),
     fetchTrendingData().catch(
@@ -317,7 +330,8 @@ async function generateSummaries(
               .map((repo) => `> ${repo.cfg.name}: ${repo.fetchError}`)
               .join("\n")}\n\n`
           : "";
-      if (fetchErrors.length > 0 && !hasData) return `${skillsFetchFailed}\n\n${fetchErrors.map((repo) => `> ${repo.cfg.name}: ${repo.fetchError}`).join("\n")}`;
+      if (fetchErrors.length > 0 && !hasData)
+        return `${skillsFetchFailed}\n\n${fetchErrors.map((repo) => `> ${repo.cfg.name}: ${repo.fetchError}`).join("\n")}`;
       console.log("  [skills] Calling LLM for skills report...");
       try {
         const summary = await callLlm(
@@ -353,7 +367,9 @@ async function generateSummaries(
         }
         console.log(`  [${cfg.id}] Calling LLM for peer summary...`);
         try {
-          const summary = await callLlm(buildPeerPrompt(cfg, issues, prs, releases, dateStr, undefined, undefined, lang));
+          const summary = await callLlm(
+            buildPeerPrompt(cfg, issues, prs, releases, dateStr, undefined, undefined, lang),
+          );
           console.log(`  [${cfg.id}] Peer summary ready.`);
           return {
             config: cfg,
@@ -555,7 +571,8 @@ async function saveContentReport(
   const hasNewContent = webResults.some((r) => r.newItems.length > 0);
   const reportBaseId = track.id;
   const reportLabel = track.report?.label ?? track.id;
-  const reportTitle = lang === "en" ? track.report?.titleEn ?? track.name : track.report?.titleZh ?? track.name;
+  const reportTitle =
+    lang === "en" ? (track.report?.titleEn ?? track.name) : (track.report?.titleZh ?? track.name);
 
   if (hasNewContent) {
     console.log(`  [content/${track.id}/${lang}] Calling LLM for content report...`);
@@ -796,7 +813,14 @@ async function main(): Promise<void> {
       footer,
       "zh",
     );
-    const skillsContent = buildSkillsReportContent(SKILLS_REPOS, zhSummaries.skillsSummary, utcStr, dateStr, footer, "zh");
+    const skillsContent = buildSkillsReportContent(
+      SKILLS_REPOS,
+      zhSummaries.skillsSummary,
+      utcStr,
+      dateStr,
+      footer,
+      "zh",
+    );
     const openclawContent = buildOpenclawReportContent(
       fetchedOpenclaw,
       zhSummaries.peerDigests,
@@ -817,11 +841,7 @@ async function main(): Promise<void> {
         "digest",
       );
       console.log(`  Created CLI issue (zh): ${cliUrl}`);
-      const skillsUrl = await createGitHubIssue(
-        `🧩 Skills 生态热点 ${dateStr}`,
-        skillsContent,
-        "skills",
-      );
+      const skillsUrl = await createGitHubIssue(`🧩 Skills 生态热点 ${dateStr}`, skillsContent, "skills");
       console.log(`  Created Skills issue (zh): ${skillsUrl}`);
       const openclawUrl = await createGitHubIssue(
         `🦞 OpenClaw 生态日报 ${dateStr}`,
@@ -886,12 +906,28 @@ async function main(): Promise<void> {
   await Promise.all([
     ...contentResults.map((contentTrack) =>
       genZh
-        ? saveContentReport(contentTrack.track, contentTrack.results, utcStr, dateStr, digestRepo, footer, "zh")
+        ? saveContentReport(
+            contentTrack.track,
+            contentTrack.results,
+            utcStr,
+            dateStr,
+            digestRepo,
+            footer,
+            "zh",
+          )
         : Promise.resolve(),
     ),
     ...contentResults.map((contentTrack) =>
       genEn
-        ? saveContentReport(contentTrack.track, contentTrack.results, utcStr, dateStr, digestRepo, enFooter, "en")
+        ? saveContentReport(
+            contentTrack.track,
+            contentTrack.results,
+            utcStr,
+            dateStr,
+            digestRepo,
+            enFooter,
+            "en",
+          )
         : Promise.resolve(),
     ),
   ]);

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -109,10 +109,7 @@ function buildMessage(date: string, reports: string[]): string {
   const suffix = isMonthly ? " 月报" : isWeekly ? " 周报" : "";
   const lines: string[] = [`${icon} <b>Big Model Radar${suffix} · ${date}</b>\n`];
 
-  const ordered = [
-    ...baseReports.filter((r) => !isRollup(r)),
-    ...baseReports.filter((r) => isRollup(r)),
-  ];
+  const ordered = [...baseReports.filter((r) => !isRollup(r)), ...baseReports.filter((r) => isRollup(r))];
 
   for (const r of ordered) {
     const zhLabel = getShortLabel(r);

--- a/src/trending.ts
+++ b/src/trending.ts
@@ -103,7 +103,9 @@ async function fetchWithRetry(url: string, init: RetryRequestInit = {}): Promise
 
       if (attempt < FETCH_MAX_RETRIES && isRetryableStatus(response.status)) {
         const waitMs = getRetryDelayMs(attempt, response.headers.get("retry-after"));
-        console.warn(`  [trending] ${response.status} for ${url} — retry ${attempt + 1}/${FETCH_MAX_RETRIES} in ${waitMs}ms`);
+        console.warn(
+          `  [trending] ${response.status} for ${url} — retry ${attempt + 1}/${FETCH_MAX_RETRIES} in ${waitMs}ms`,
+        );
         await sleep(waitMs);
         continue;
       }

--- a/src/web.ts
+++ b/src/web.ts
@@ -183,7 +183,10 @@ function decodeEntities(text: string): string {
 }
 
 function stripTags(text: string): string {
-  return decodeEntities(text).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  return decodeEntities(text)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function extractTag(block: string, tag: string): string {
@@ -221,13 +224,11 @@ function isSitemapIndex(xml: string): boolean {
 
 function extractTitle(html: string): string {
   return (
-    (
-      html.match(/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']{1,200})["']/i)?.[1] ??
-      html.match(/<meta[^>]+content=["']([^"']{1,200})["'][^>]+property=["']og:title["']/i)?.[1] ??
-      html.match(/<title[^>]*>([^<]{1,200})<\/title>/i)?.[1] ??
-      ""
-    ).trim()
-  );
+    html.match(/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']{1,200})["']/i)?.[1] ??
+    html.match(/<meta[^>]+content=["']([^"']{1,200})["'][^>]+property=["']og:title["']/i)?.[1] ??
+    html.match(/<title[^>]*>([^<]{1,200})<\/title>/i)?.[1] ??
+    ""
+  ).trim();
 }
 
 function extractText(html: string): string {
@@ -312,7 +313,11 @@ function emptyState(): ContentState {
 function isSourceState(value: unknown): value is SourceState {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<SourceState>;
-  return typeof candidate.lastChecked === "string" && typeof candidate.seenUrls === "object" && candidate.seenUrls !== null;
+  return (
+    typeof candidate.lastChecked === "string" &&
+    typeof candidate.seenUrls === "object" &&
+    candidate.seenUrls !== null
+  );
 }
 
 function normalizeState(raw: unknown): ContentState {
@@ -503,7 +508,10 @@ async function buildFeedItems(source: ContentSource, entries: FeedEntry[]): Prom
 // Main export
 // ---------------------------------------------------------------------------
 
-export async function fetchSiteContent(source: ContentSource, state: ContentState): Promise<ContentFetchResult> {
+export async function fetchSiteContent(
+  source: ContentSource,
+  state: ContentState,
+): Promise<ContentFetchResult> {
   const sourceState = getSourceState(state, source.id);
   const isFirstRun = Object.keys(sourceState.seenUrls).length === 0;
 


### PR DESCRIPTION
### Motivation
- CI `prettier --check src` was failing due to code style issues in several source files, causing the workflow to exit with an error. 
- The goal is to restore CI to a green state by applying the repository's Prettier formatting rules.

### Description
- Applied Prettier formatting across the codebase (whitespace, wrapping and minor reflow only) to satisfy `prettier` rules. 
- Files updated: `src/config.ts`, `src/hn.ts`, `src/index.ts`, `src/notify.ts`, `src/trending.ts`, and `src/web.ts`.
- All edits are stylistic and do not change program logic or behavior.

### Testing
- Ran `pnpm format` to apply formatting changes and it completed successfully. 
- Verified formatting now passes with `pnpm format:check` (which runs `prettier --check src`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f80fb91a20832992dbca4186c6b3e9)